### PR TITLE
添加文件校验

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3222,6 +3222,9 @@ class DagModel(Base):
         dag_models = session.query(cls).all()
         for dag_model in dag_models:
             if dag_model.fileloc is not None:
+                if os.path.exists(dag_model.fileloc) and os.path.isfile(dag_model.fileloc):
+                    # cdk将不同venv的所有dag放在同一个目录下，所以如果dag地址是一个文件且文件仍旧存在，则认为该dag仍旧有效
+                    continue
                 if correct_maybe_zipped(dag_model.fileloc) not in alive_dag_filelocs:
                     dag_model.is_active = False
             else:

--- a/shinny-changelog.md
+++ b/shinny-changelog.md
@@ -1,0 +1,15 @@
+# Shinny 定制化 Airflow 变更记录
+
+## BackPort Bugfix
+- 从上游backport bugfix ((fix: force DAG last modified time to UTC (#30243))[https://github.com/apache/airflow/pull/30243]) 到 2.4.0 版本
+
+## CI打包
+- 添加 shinny-release.yml, github action 产出python包并放入shinny-cd
+
+## Dag processing
+- 修改 `airflow/models/dag.py` 中的 `deactivate_deleted_dags` 方法, 使通过venv解释器刷新部分dag时不会将还存在于硬盘上的dag标记为失效
+  - 经讨论验证废除方案：通过 `multiprocessing.context.set_executable` 修改context.process进程的python解释器, 但是这样无法正常使用venv中的包
+
+## Dag 执行
+- 修改 `airflow/executors/local_executor.py` 中的 `_execute_work_in_subprocess` 方法, 使其在执行cdk部署的dag时使用venv中的python解释器
+  - 经讨论验证废除方案：通过 `multiprocessing.context.set_executable` 修改context.process进程的python解释器, 但是这样无法正常使用venv中的包


### PR DESCRIPTION
当dag刷新的时候，airflow默认会将所有不属于当前subdir的置为deactivate。
但在我们的场景下，dag process通过venv的python执行，即使按照设计所有dag在同一个文件夹下也因为不同dag需要不同venv的解释器而无法一次性处理所有dag。
同时，确实需要检测dag删除后清理mysql中的dag（默认超时机制是600s后删除过期dag）

因此为了满足dag-process时按照dag入口文件为单位进行刷新，在清理dag的函数中加入了文件是否存在于硬盘上的判断逻辑。

**注意：在所有dag都被删除后，最后一批dag因为硬盘上没有其余dag帮助触发dag-process，因此需要等待超时删除。其余情况应会立即删除。**