### PR TITLE
remove lazy load from TaskInstance.DagModel

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1486,7 +1486,8 @@ class SchedulerJob(BaseJob):
             zombies: list[tuple[TI, str, str]] = (
                 session.query(TI, DM.fileloc, DM.processor_subdir)
                 .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
-                .join(LocalTaskJob, TaskInstance.job_id == LocalTaskJob.id)
+                .join(LocalTaskJob, TI.job_id == LocalTaskJob.id)
+                .join(DM, TI.dag_id == DM.dag_id)
                 .filter(TI.state == TaskInstanceState.RUNNING)
                 .filter(
                     or_(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1471,8 +1471,7 @@ class SchedulerJob(BaseJob):
         if num_timed_out_tasks:
             self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
 
-    @provide_session
-    def _find_zombies(self, session: Session) -> None:
+    def _find_zombies(self) -> None:
         """
         Find zombie task instances, which are tasks haven't heartbeated for too long
         or have a no-longer-running LocalTaskJob, and create a TaskCallbackRequest
@@ -1483,31 +1482,30 @@ class SchedulerJob(BaseJob):
         self.log.debug("Finding 'running' jobs without a recent heartbeat")
         limit_dttm = timezone.utcnow() - timedelta(seconds=self._zombie_threshold_secs)
 
-        zombies = (
-            session.query(TaskInstance, DagModel.fileloc)
-            .with_hint(TI, 'USE INDEX (ti_state)', dialect_name='mysql')
-            .join(LocalTaskJob, TaskInstance.job_id == LocalTaskJob.id)
-            .join(DagModel, TaskInstance.dag_id == DagModel.dag_id)
-            .filter(TaskInstance.state == TaskInstanceState.RUNNING)
-            .filter(
-                or_(
-                    LocalTaskJob.state != State.RUNNING,
-                    LocalTaskJob.latest_heartbeat < limit_dttm,
+        with create_session() as session:
+            zombies: list[tuple[TI, str, str]] = (
+                session.query(TI, DM.fileloc, DM.processor_subdir)
+                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+                .join(LocalTaskJob, TaskInstance.job_id == LocalTaskJob.id)
+                .filter(TI.state == TaskInstanceState.RUNNING)
+                .filter(
+                    or_(
+                        LocalTaskJob.state != State.RUNNING,
+                        LocalTaskJob.latest_heartbeat < limit_dttm,
+                    )
                 )
+                .filter(TI.queued_by_job_id == self.id)
+                .all()
             )
-            .filter(TaskInstance.queued_by_job_id == self.id)
-            .all()
-        )
 
         if zombies:
             self.log.warning("Failing (%s) jobs without heartbeat after %s", len(zombies), limit_dttm)
 
-        for ti, file_loc in zombies:
-
+        for ti, file_loc, processor_subdir in zombies:
             zombie_message_details = self._generate_zombie_message_details(ti)
             request = TaskCallbackRequest(
                 full_filepath=file_loc,
-                processor_subdir=ti.dag_model.processor_subdir,
+                processor_subdir=processor_subdir,
                 simple_task_instance=SimpleTaskInstance.from_ti(ti),
                 msg=str(zombie_message_details),
             )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4005,14 +4005,13 @@ class TestSchedulerJob:
         assert ti2.state == State.DEFERRED
 
     def test_find_zombies_nothing(self):
-        with create_session() as session:
-            executor = MockExecutor(do_update=False)
-            self.scheduler_job = SchedulerJob(executor=executor)
-            self.scheduler_job.processor_agent = mock.MagicMock()
+        executor = MockExecutor(do_update=False)
+        self.scheduler_job = SchedulerJob(executor=executor)
+        self.scheduler_job.processor_agent = mock.MagicMock()
 
-            self.scheduler_job._find_zombies(session=session)
+        self.scheduler_job._find_zombies()
 
-            self.scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.scheduler_job.executor.callback_sink.send.assert_not_called()
 
     def test_find_zombies(self):
         dagbag = DagBag(TEST_DAG_FOLDER, read_dags_from_db=False)
@@ -4055,20 +4054,21 @@ class TestSchedulerJob:
             ti.queued_by_job_id = self.scheduler_job.id
             session.flush()
 
-            self.scheduler_job._find_zombies(session=session)
+        self.scheduler_job._find_zombies()
 
-            self.scheduler_job.executor.callback_sink.send.assert_called_once()
-            requests = self.scheduler_job.executor.callback_sink.send.call_args[0]
-            assert 1 == len(requests)
-            assert requests[0].full_filepath == dag.fileloc
-            assert requests[0].msg == str(self.scheduler_job._generate_zombie_message_details(ti))
-            assert requests[0].is_failure_callback is True
-            assert isinstance(requests[0].simple_task_instance, SimpleTaskInstance)
-            assert ti.dag_id == requests[0].simple_task_instance.dag_id
-            assert ti.task_id == requests[0].simple_task_instance.task_id
-            assert ti.run_id == requests[0].simple_task_instance.run_id
-            assert ti.map_index == requests[0].simple_task_instance.map_index
+        self.scheduler_job.executor.callback_sink.send.assert_called_once()
+        requests = self.scheduler_job.executor.callback_sink.send.call_args[0]
+        assert 1 == len(requests)
+        assert requests[0].full_filepath == dag.fileloc
+        assert requests[0].msg == str(self.scheduler_job._generate_zombie_message_details(ti))
+        assert requests[0].is_failure_callback is True
+        assert isinstance(requests[0].simple_task_instance, SimpleTaskInstance)
+        assert ti.dag_id == requests[0].simple_task_instance.dag_id
+        assert ti.task_id == requests[0].simple_task_instance.task_id
+        assert ti.run_id == requests[0].simple_task_instance.run_id
+        assert ti.map_index == requests[0].simple_task_instance.map_index
 
+        with create_session() as session:
             session.query(TaskInstance).delete()
             session.query(LocalTaskJob).delete()
 
@@ -4143,12 +4143,11 @@ class TestSchedulerJob:
         Check that the same set of failure callback with zombies are passed to the dag
         file processors until the next zombie detection logic is invoked.
         """
-        with conf_vars({('core', 'load_examples'): 'False'}):
+        with conf_vars({("core", "load_examples"): "False"}), create_session() as session:
             dagbag = DagBag(
                 dag_folder=os.path.join(settings.DAGS_FOLDER, "test_example_bash_operator.py"),
                 read_dags_from_db=False,
             )
-            session = settings.Session()
             session.query(LocalTaskJob).delete()
             dag = dagbag.get_dag('test_example_bash_operator')
             dag.sync_to_db(processor_subdir=TEST_DAG_FOLDER)
@@ -4177,7 +4176,7 @@ class TestSchedulerJob:
         self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.processor_agent = mock.MagicMock()
 
-        self.scheduler_job._find_zombies(session=session)
+        self.scheduler_job._find_zombies()
 
         self.scheduler_job.executor.callback_sink.send.assert_called_once()
 


### PR DESCRIPTION
# 背景
单个dag含有多个任务，且多个任务都发生故障进入僵尸状态后会导致scheduler崩溃
相关上游issue：
- https://github.com/apache/airflow/pull/28198
- https://github.com/apache/airflow/pull/28544

# 方案
cherry-pick 上有更改修复sql查询语句问题

## 日志
```
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: [2024-03-27 20:27:03,752] {scheduler_job.py:1503} WARNING - Failing (2) jobs without heartbeat after 2024-03-27 12:22:03.749656+00:00
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: [2024-03-27 20:27:03,755] {scheduler_job.py:1514} ERROR - Detected zombie job: {'full_filepath': '/var/lib/ef/airflow/dags/ins-serve-ins-serve-i>
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: [2024-03-27 20:27:03,758] {scheduler_job.py:763} ERROR - Exception when executing SchedulerJob._run_scheduler_loop
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: Traceback (most recent call last):
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 746, in _execute
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     self._run_scheduler_loop()
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 873, in _run_scheduler_loop
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     next_event = timers.run(blocking=False)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/lib/python3.9/sched.py", line 151, in run
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*argument, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/event_scheduler.py", line 37, in repeat
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*args, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/session.py", line 75, in wrapper
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return func(*args, session=session, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     self._run_scheduler_loop()
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 873, in _run_scheduler_loop
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     next_event = timers.run(blocking=False)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/lib/python3.9/sched.py", line 151, in run
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*argument, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/event_scheduler.py", line 37, in repeat
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*args, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/session.py", line 75, in wrapper
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return func(*args, session=session, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 1510, in _find_zombies
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     processor_subdir=ti.dag_model.processor_subdir,
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 481, in __get__
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return self.impl.get(state, dict_)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 926, in get
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     value = self._fire_loader_callables(state, key, passive)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 962, in _fire_loader_callables
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return self.callable_(state, passive)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/strategies.py", line 861, in _load_for_state
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     raise orm_exc.DetachedInstanceError(
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <TaskInstance at 0x7fc88e0d90a0> is not bound to a Session; lazy load operation of att>
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: [2024-03-27 20:27:03,760] {local_executor.py:428} INFO - Shutting down LocalExecutor; waiting for running tasks to finish.  Signal again if you >
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: [2024-03-27 20:27:03,839] {scheduler_job.py:775} INFO - Exited execute loop
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724892]: [2024-03-27 20:27:03 +0800] [3724892] [INFO] Handling signal: term
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724894]: [2024-03-27 20:27:03 +0800] [3724894] [INFO] Worker exiting (pid: 3724894)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: Traceback (most recent call last):
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/bin/airflow", line 8, in <module>
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     sys.exit(main())
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/__main__.py", line 39, in main
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     args.func(args)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/cli/cli_parser.py", line 52, in command
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return func(*args, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/cli.py", line 99, in wrapper
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return f(*args, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/cli/commands/scheduler_command.py", line 85, in scheduler
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     _run_scheduler_job(args=args)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/cli/commands/scheduler_command.py", line 50, in _run_scheduler_job
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     job.run()
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/base_job.py", line 247, in run
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     self._execute()
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 746, in _execute
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     self._run_scheduler_loop()
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 873, in _run_scheduler_loop
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     next_event = timers.run(blocking=False)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/lib/python3.9/sched.py", line 151, in run
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*argument, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/event_scheduler.py", line 37, in repeat
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     action(*args, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/utils/session.py", line 75, in wrapper
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return func(*args, session=session, **kwargs)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/scheduler_job.py", line 1510, in _find_zombies
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     processor_subdir=ti.dag_model.processor_subdir,
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 481, in __get__
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return self.impl.get(state, dict_)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 926, in get
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     value = self._fire_loader_callables(state, key, passive)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/attributes.py", line 962, in _fire_loader_callables
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     return self.callable_(state, passive)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:   File "/usr/local/lib/python3.9/dist-packages/sqlalchemy/orm/strategies.py", line 861, in _load_for_state
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]:     raise orm_exc.DetachedInstanceError(
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724886]: sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <TaskInstance at 0x7fc88e0d90a0> is not bound to a Session; lazy load operation of att>
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724961]: [2024-03-27 20:27:03 +0800] [3724961] [INFO] Worker exiting (pid: 3724961)
Mar 27 20:27:03 airflow-service-ali-all-in-one airflow[3724892]: [2024-03-27 20:27:03 +0800] [3724892] [INFO] Shutting down: Master
```
