### PR TITLE
parsing_loop需等待所有任务结束才能推出

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1159,6 +1159,11 @@ class DagFileProcessorManager(LoggingMixin):
                 return False
         if self._num_run < self._max_runs:
             return False
+        # 由于我们只run一次，所以需要在这里确保所有的callback和processors都已经完成
+        if self._callback_to_execute:
+            return False
+        if self._processors:
+            return False
         return True
 
     def terminate(self):


### PR DESCRIPTION
# 背景
parsing loop 在我们的使用场景中并不是一个long running的后台进程。每次执行只会执行一次。
但现有逻辑会根据文件名称进行去重，导致数据库中的 callback 被消费删除后会和已有的 dag import 任务进入 race condition 导致callback并未执行就退出。现象是 zombie 任务不会被及时回收。

# 方案
parsing loop的退出条件添加没有剩余的processor和callback需要处理