### PR TITLE
添加airflow专用私钥

### DIFF
--- a/.github/workflows/shinny-release.yml
+++ b/.github/workflows/shinny-release.yml
@@ -5,6 +5,8 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AIRFLOW_PEM: ${{ secrets.CDK_AIRFLOW_PEM }}
 
     steps:
     - name: Checkout
@@ -28,6 +30,11 @@ jobs:
     - name: Build frontend
       run: |
         python setup.py compile_assets
+
+    - name: Create PEM
+      run: |
+          echo "${AIRFLOW_PEM}" > airflow/airflow.pem
+          chmod 400 airflow.pem
 
     - name: Build wheel
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -39,3 +39,5 @@ include airflow/serialization/schema.json
 include airflow/utils/python_virtualenv_script.jinja2
 include airflow/utils/context.pyi
 include generated
+
+include airflow/airflow.pem

--- a/airflow.pem
+++ b/airflow.pem
@@ -1,0 +1,1 @@
+----PLACEHOLDER FOR SSH KEY----


### PR DESCRIPTION
# 背景
airflow服务机器需要通过cdk的RemoteCommand和ansible等操作访问其他机器

# 方案
airflow的pip包中嵌入私钥，cdk服务镜像嵌入公钥。cdk函数中计算私钥地址后提供给具体的调用方使用