### PR TITLE
清理import_error时考虑所有dags文件夹下的dag文件

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -50,6 +50,7 @@ from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.stats import Stats
+from airflow.settings import DAGS_FOLDER
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths, might_contain_dag
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -776,7 +777,8 @@ class DagFileProcessorManager(LoggingMixin):
         """
         query = session.query(errors.ImportError)
         if self._file_paths:
-            query = query.filter(~errors.ImportError.filename.in_(self._file_paths))
+            # extend to all files in the dag_folder
+            query = query.filter(~errors.ImportError.filename.in_([os.path.join(DAGS_FOLDER, file_path) for file_path in os.listdir(DAGS_FOLDER)]))
         query.delete(synchronize_session='fetch')
         session.commit()
 


### PR DESCRIPTION
fixes: https://github.com/shinnytech/airflow/issues/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了查询过滤器，现在可以包括所有在指定文件夹中的文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->