### PR TITLE
force DagModel to use joined eager load

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3033,10 +3033,10 @@ class DagModel(Base):
     # Timetable/Schedule Interval description
     timetable_description = Column(String(1000), nullable=True)
     # Tags for view filter
-    tags = relationship('DagTag', cascade='all, delete, delete-orphan', backref=backref('dag'))
+    tags = relationship('DagTag', cascade='all, delete, delete-orphan', backref=backref('dag'), lazy="joined")
     # Dag owner links for DAGs view
     dag_owner_links = relationship(
-        'DagOwnerAttributes', cascade='all, delete, delete-orphan', backref=backref('dag')
+        'DagOwnerAttributes', cascade='all, delete, delete-orphan', backref=backref('dag'), lazy="joined"
     )
 
     max_active_tasks = Column(Integer, nullable=False)
@@ -3061,16 +3061,18 @@ class DagModel(Base):
     )
 
     parent_dag = relationship(
-        "DagModel", remote_side=[dag_id], primaryjoin=root_dag_id == dag_id, foreign_keys=[root_dag_id]
+        "DagModel", remote_side=[dag_id], primaryjoin=root_dag_id == dag_id, foreign_keys=[root_dag_id], lazy="joined"
     )
     schedule_dataset_references = relationship(
         "DagScheduleDatasetReference",
         cascade='all, delete, delete-orphan',
+        lazy="joined"
     )
     schedule_datasets = association_proxy('schedule_dataset_references', 'dataset')
     task_outlet_dataset_references = relationship(
         "TaskOutletDatasetReference",
         cascade='all, delete, delete-orphan',
+        lazy="joined"
     )
     NUM_DAGS_PER_DAGRUN_QUERY = conf.getint('scheduler', 'max_dagruns_to_create_per_loop', fallback=10)
 
@@ -3458,7 +3460,7 @@ if STATICA_HACK:  # pragma: no cover
 
     from airflow.models.serialized_dag import SerializedDagModel
 
-    DagModel.serialized_dag = relationship(SerializedDagModel)
+    DagModel.serialized_dag = relationship(SerializedDagModel, lazy="joined")
     """:sphinx-autoapi-skip:"""
 
 


### PR DESCRIPTION
# 背景
https://github.com/shinnytech/airflow/pull/6 修复了部分dagmodel的懒加载问题，但是webserver侧flask加载dagmodel又出现了问题
![image](https://github.com/shinnytech/airflow/assets/116700000/4947be98-af49-405c-9588-414c119586c2)

# 方案
将所有DadModel类中的懒加载全部关闭，采用[joined eager loading](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **性能优化**
  - 优化了多个关系的加载方式，提高了应用的性能和响应速度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->