### PR TITLE
适配shinny pip index规范

### DIFF
--- a/.github/workflows/shinny-release.yml
+++ b/.github/workflows/shinny-release.yml
@@ -20,6 +20,14 @@ jobs:
         node-version: 14
     - run: npm install -g yarn
 
+    - name: Edit version
+      if: startsWith(github.event.ref, 'refs/tags')
+      run: sed -i "s@2\.4\.0@$(echo ${GITHUB_REF##*/})@" setup.py
+
+    - name: Edit version
+      if: startsWith(github.event.ref, 'refs/tags') != true
+      run: sed -i "s@2\.4\.0@2\.4\.0+$(echo ${GITHUB_REF##*/})\.$(echo ${GITHUB_SHA:0:7})@" setup.py
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -51,5 +59,5 @@ jobs:
         access-key-secret: ${{ secrets.OSS_SECRET_KEY }}
 
     - name: Upload to oss
-      run: ossutil cp -rf dist oss://shinny-cd/airflow/${DEST_DIR}
+      run: ossutil cp -rf dist oss://shinny-cd/apache-airflow/${DEST_DIR}
 


### PR DESCRIPTION
- shinny pip index 规范中规定服务名需要和 python 包名前缀相符，且需要放置在对应的 oss 文件夹下
- airflow需要被其他插件依赖，因此版本号不能是 0.0.0